### PR TITLE
fflush(stdout); so doesn't buffer when piping to mosquitto_pub

### DIFF
--- a/pms5003.c
+++ b/pms5003.c
@@ -73,6 +73,7 @@ void print_data(size_t num_measurements, double *data)
     printf(",\"%s\":%.02f", labels[i], data[i]);
 
   printf("}\n");
+  fflush(stdout);
 }
 
 double avg_sum[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
If sending with mosquitto_pub without fflush I get 16 messages being sent at once to the mqtt broker. With the fflush added I get one message a second without any bursts of messages. Not quite sure why piping to another application needs a fflush but displaying to the terminal the fflush isn't needed.

Setup:
On a raspbbery pi with a CH340 USB serial dongle. Using `./pms5003 /dev/ttyUSB0 | mosquitto_pub -t air/ppm -l` to a local mqtt  broker (mosquitto). 
